### PR TITLE
Fix handling of GitHub HTTPS remote

### DIFF
--- a/src/hosts/github.js
+++ b/src/hosts/github.js
@@ -13,6 +13,10 @@ class GitHub {
      * @returns string
      */
     repositoryName() {
+        if (this.remoteUrl.includes('https://')) {
+            return this.remoteUrl.replace(/(https:\/\/github.com\/|\.git)/g, '');
+        }
+
         return this.remoteUrl.replace(/(.git|git@github.com:)/g, '');
     }
 


### PR DESCRIPTION
This pull request aims to fix an issue where GitHub HTTPS remotes weren't supported.

Fixes #2.