### PR TITLE
Pin GitHub Actions to SHAs and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # Supply chain attack mitigation: wait 7 days before updating
+    # to allow community detection of compromised releases
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       - name: Get Changelog
         id: changelog
-        uses: statamic/changelog-action@v1
+        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1
         with:
           version: ${{ github.ref }}
 
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -38,7 +38,7 @@ jobs:
           prerelease: ${{ contains(github.ref, '-beta') }}
 
       - name: Comment on related issues
-        uses: duncanmcclean/post-release-comments@v1.0.6
+        uses: duncanmcclean/post-release-comments@ee2d062e73bd6f0898f36ed892953ed88134cc19 # v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This pull request improves supply chain security for GitHub Actions.

It pins all GitHub Action dependencies to commit SHAs instead of version tags. This prevents potential supply chain attacks where a malicious actor could compromise a tag and inject malicious code into the workflow.

This PR also adds a Dependabot configuration to automatically update GitHub Actions dependencies weekly, with a 7-day cooldown period to allow community detection of compromised releases before they're adopted.